### PR TITLE
Add Varlamore clue IDs

### DIFF
--- a/src/main/java/sky/clueSteps/ClueWithConfig.java
+++ b/src/main/java/sky/clueSteps/ClueWithConfig.java
@@ -189,7 +189,9 @@ enum ClueWithConfig
 			23165,
 			23166,
 			25788,
-			25789
+			25789,
+			28913,
+			28914
 	};
 
 	private static final int[] mediumIDs = {
@@ -350,7 +352,10 @@ enum ClueWithConfig
 			23142,
 			23143,
 			25783,
-			25784
+			25784,
+			28907, // this is a challenge scroll, it does not follow normal clue standards
+			28908,
+			28909
 	};
 
 	private static final int[] hardIDs = {
@@ -532,7 +537,10 @@ enum ClueWithConfig
 			25790,
 			25791,
 			25792,
-			26566
+			26566,
+			28915,
+			28916,
+			28918
 	};
 
 	private static final int[] eliteIDs = {
@@ -662,7 +670,10 @@ enum ClueWithConfig
 			25498,
 			25499,
 			25786,
-			25787
+			25787,
+			28910,
+			28911,
+			28912
 	};
 
 	private static final int[] masterIDs = {

--- a/src/main/java/sky/clueSteps/ClueWithConfig.java
+++ b/src/main/java/sky/clueSteps/ClueWithConfig.java
@@ -531,7 +531,8 @@ enum ClueWithConfig
 			24493,
 			25790,
 			25791,
-			25792
+			25792,
+			26566
 	};
 
 	private static final int[] eliteIDs = {


### PR DESCRIPTION
Adds the new Varlamore clues, IDs are sourced from the wiki except for easy clues and 2/3 of the mediums which I confirmed manually in-game.

Currently the medium clue `28907` is incorrectly labeled in-game as a `Challenge scroll (medium)`, including the "wrong" options/examine text - I did include it in this PR but I did not test to make sure doing this would not cause an issue, but I'm doubtful it will.

edit: In today's update the above mentioned clue had its name changed, but it still functions as a challenge scroll, meaning it's missing the Check-steps option.